### PR TITLE
docs: Add Code of Conduct link and EU funding logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ We as members, contributors, and leaders pledge to make participation in our com
 ## Licensing
 
 Copyright (20xx-)20xx SAP SE or an SAP affiliate company and <your-project> contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/openkcm/checker).
+
+<p align="center"><img alt="Bundesministerium für Wirtschaft und Klimaschutz (BMWK)-EU funding logo" src="https://apeirora.eu/assets/img/BMWK-EU.png" width="400"/></p>


### PR DESCRIPTION
This PR adds a link to the Code of Conduct and the EU funding logo to the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added EU funding logo image to the README licensing section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->