### PR TITLE
fix: extract repeated error strings into named constants

### DIFF
--- a/internal/healthcheck/cluster.go
+++ b/internal/healthcheck/cluster.go
@@ -23,7 +23,7 @@ func verifyServiceResource(ctx context.Context, rc *config.Resource) (*Response,
 	if err != nil {
 		errors = append(errors, ErrorResponse{
 			Message: err.Error(),
-			Error:   "Bad Request",
+			Error:   ERR_BAD_REQUEST,
 		})
 		response.Errors = errors
 		response.Status = NOTOK
@@ -35,7 +35,7 @@ func verifyServiceResource(ctx context.Context, rc *config.Resource) (*Response,
 	if err != nil {
 		errors = append(errors, ErrorResponse{
 			Message: err.Error(),
-			Error:   "Reading Response Body",
+			Error:   ERR_READING_RESPONSE_BODY,
 		})
 		response.Errors = errors
 		response.Status = NOTOK
@@ -50,7 +50,7 @@ func verifyServiceResource(ctx context.Context, rc *config.Resource) (*Response,
 	if err != nil {
 		errors = append(errors, ErrorResponse{
 			Message: err.Error(),
-			Error:   "Reading Response Body",
+			Error:   ERR_READING_RESPONSE_BODY,
 		})
 		response.Errors = errors
 		response.Status = NOTOK

--- a/internal/healthcheck/kubernetes.go
+++ b/internal/healthcheck/kubernetes.go
@@ -39,7 +39,7 @@ func verifyK8SResource(ctx context.Context, rc *config.Resource) (*Response, int
 	if err != nil {
 		errors = append(errors, ErrorResponse{
 			Message: err.Error(),
-			Error:   "Bad Request",
+			Error:   ERR_BAD_REQUEST,
 		})
 		response.Errors = errors
 		response.Status = NOTOK
@@ -51,7 +51,7 @@ func verifyK8SResource(ctx context.Context, rc *config.Resource) (*Response, int
 	if err != nil {
 		errors = append(errors, ErrorResponse{
 			Message: err.Error(),
-			Error:   "Bad Request",
+			Error:   ERR_BAD_REQUEST,
 		})
 		response.Errors = errors
 		response.Status = NOTOK
@@ -63,7 +63,7 @@ func verifyK8SResource(ctx context.Context, rc *config.Resource) (*Response, int
 	if err != nil {
 		errors = append(errors, ErrorResponse{
 			Message: err.Error(),
-			Error:   "Bad Request",
+			Error:   ERR_BAD_REQUEST,
 		})
 		response.Errors = errors
 		response.Status = NOTOK
@@ -77,7 +77,7 @@ func verifyK8SResource(ctx context.Context, rc *config.Resource) (*Response, int
 	if err != nil {
 		errors = append(errors, ErrorResponse{
 			Message: err.Error(),
-			Error:   "Bad Request",
+			Error:   ERR_BAD_REQUEST,
 		})
 		response.Errors = errors
 		response.Status = NOTOK
@@ -89,7 +89,7 @@ func verifyK8SResource(ctx context.Context, rc *config.Resource) (*Response, int
 	if err != nil {
 		errors = append(errors, ErrorResponse{
 			Message: err.Error(),
-			Error:   "Reading Response Body",
+			Error:   ERR_READING_RESPONSE_BODY,
 		})
 		response.Errors = errors
 		response.Status = NOTOK
@@ -104,7 +104,7 @@ func verifyK8SResource(ctx context.Context, rc *config.Resource) (*Response, int
 	if err != nil {
 		errors = append(errors, ErrorResponse{
 			Message: err.Error(),
-			Error:   "Reading Response Body",
+			Error:   ERR_READING_RESPONSE_BODY,
 		})
 		response.Errors = errors
 		response.Status = NOTOK

--- a/internal/healthcheck/types.go
+++ b/internal/healthcheck/types.go
@@ -4,6 +4,8 @@ const (
 	OK                            = "OK"
 	OK_TOLERATED_FAILURE_ON_RETRY = "OK [FAILURE TOLERATED ON RETRY]"
 	NOTOK                         = "NOT OK"
+	ERR_BAD_REQUEST               = "Bad Request"
+	ERR_READING_RESPONSE_BODY     = "Reading Response Body"
 )
 
 type Response struct {


### PR DESCRIPTION
Replaces inline string literals with ERR_BAD_REQUEST and ERR_READING_RESPONSE_BODY constants to satisfy linter checks.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Error handling in health check verification processes has been standardized. Error reporting in both cluster and Kubernetes resource verification now uses consistent, centrally-defined error codes instead of scattered individual string messages found throughout the codebase. The specific error messages visible to end-users remain completely unchanged by these updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openkcm/checker/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->