### PR TITLE
Add ability to mask url and msgs to api response

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -75,6 +75,9 @@ linters:
           - goconst
           - maintidx
         path: (.+)_test\.go
+      - linters:
+          - tagliatelle
+        text: "yaml\\(camel\\): got 'maskURLs'"
     paths:
       - vendor
       - third_party$

--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,7 @@ healthcheck:
   endpoint: "/healthz"
   enabled: true
   refreshDuration: 3s
+  maskURLs: false
   cluster:
     enabled: true
     resources:

--- a/internal/business/server/healthcheck_handler.go
+++ b/internal/business/server/healthcheck_handler.go
@@ -21,6 +21,49 @@ import (
 	"github.com/openkcm/checker/internal/healthcheck"
 )
 
+func maskResponse(r *healthcheck.Response) *healthcheck.Response {
+	cloned := *r
+	cloned.URL = "****"
+
+	if len(r.Errors) > 0 {
+		maskedErrors := make([]healthcheck.ErrorResponse, len(r.Errors))
+
+		for i, e := range r.Errors {
+			maskedErrors[i] = e
+			if maskedErrors[i].Message != "" {
+				maskedErrors[i].Message = "****"
+			}
+		}
+
+		cloned.Errors = maskedErrors
+	}
+
+	return &cloned
+}
+
+func maskURLs(response map[string]any) map[string]any {
+	masked := make(map[string]any, len(response))
+
+	for k, v := range response {
+		switch val := v.(type) {
+		case []*healthcheck.Response:
+			maskedList := make([]*healthcheck.Response, len(val))
+
+			for i, r := range val {
+				maskedList[i] = maskResponse(r)
+			}
+
+			masked[k] = maskedList
+		case *healthcheck.Response:
+			masked[k] = maskResponse(val)
+		default:
+			masked[k] = v
+		}
+	}
+
+	return masked
+}
+
 func healthcheckHandlerFunc(operation string, cfg *config.Config, ch *healthcheck.CachedResponses) func(http.ResponseWriter, *http.Request) {
 	traceAttrs := otlp.CreateAttributesFrom(cfg.Application,
 		attribute.String(commoncfg.AttrOperation, operation),
@@ -68,11 +111,18 @@ func healthcheckHandlerFunc(operation string, cfg *config.Config, ch *healthchec
 
 		w.Header().Set("Content-Type", "application/json")
 
+		rawResponse := ch.Response()
+		response := rawResponse
+
+		if cfg.Healthcheck.MaskURLs {
+			response = maskURLs(rawResponse)
+		}
+
 		w.WriteHeader(ch.Status())
-		_ = json.NewEncoder(w).Encode(ch.Response())
+		_ = json.NewEncoder(w).Encode(response)
 
 		slogctx.Info(ctx, fmt.Sprintf("Finished %s request", operation),
-			"durationMs", time.Since(requestStartTime)/time.Millisecond, "response", ch.Response(), "status", ch.Status())
+			"durationMs", time.Since(requestStartTime)/time.Millisecond, "response", rawResponse, "status", ch.Status())
 		// End Business Logic
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,7 @@ type Healthcheck struct {
 	Name            string        `yaml:"name" default:"healthcheck"`
 	Endpoint        string        `yaml:"endpoint" default:"/healthz"`
 	RefreshDuration time.Duration `yaml:"refreshDuration" default:"5s"`
+	MaskURLs        bool          `yaml:"maskURLs" default:"false"`
 	Cluster         Domain        `yaml:"cluster"`
 	Kubernetes      Domain        `yaml:"kubernetes"`
 	Linkerd         Linkerd       `yaml:"linkerd"`


### PR DESCRIPTION
Adds the ability to mask the url and message in the api response from the /healthz endpoint in checker while maintaining the values in logs for operation purposes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional health-check setting to mask URLs and error messages in responses.
  * Masked values appear as `****` when enabled, while other response details remain available.
  * The setting is disabled by default and can be enabled through configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->