### PR TITLE
fix(healthcheck): initialize k8s client before running linkerd checks

### DIFF
--- a/internal/healthcheck/linkerd.go
+++ b/internal/healthcheck/linkerd.go
@@ -39,10 +39,23 @@ func verifyLinkerd(ctx context.Context, cfg *config.Linkerd) (*Response, int) {
 		APIAddr:               "",
 		VersionOverride:       "",
 		RetryDeadline:         time.Now().Add(time.Duration(cfg.RetryDeadline) * time.Second),
-		CNIEnabled:            cfg.Enabled,
+		CNIEnabled:            cfg.CNIEnabled,
 		InstallManifest:       "",
 		CRDManifest:           crdManifest.String(),
 	})
+
+	// Initialize the Kubernetes API client before running checks
+	err := hc.InitializeKubeAPIClient()
+	if err != nil {
+		slogctx.Error(ctx, "Failed to initialize Kubernetes API client for linkerd healthcheck", "error", err)
+		return &Response{
+			Status: NOTOK,
+			Errors: []ErrorResponse{{
+				Error:   err.Error(),
+				Message: "Failed to initialize Kubernetes API client",
+			}},
+		}, http.StatusServiceUnavailable
+	}
 
 	// Run the healthchecks using the new API
 	success, _ := hc.RunChecks(func(result *healthcheck.CheckResult) {

--- a/internal/healthcheck/linkerd.go
+++ b/internal/healthcheck/linkerd.go
@@ -48,6 +48,7 @@ func verifyLinkerd(ctx context.Context, cfg *config.Linkerd) (*Response, int) {
 	err := hc.InitializeKubeAPIClient()
 	if err != nil {
 		slogctx.Error(ctx, "Failed to initialize Kubernetes API client for linkerd healthcheck", "error", err)
+
 		return &Response{
 			Status: NOTOK,
 			Errors: []ErrorResponse{{


### PR DESCRIPTION
## Problem Description
The linkerd healthcheck library requires the Kubernetes API client to be initialized via `InitializeKubeAPIClient()` before `RunChecks()` is called. Without this initialization, `hc.kubeAPI` is nil, causing a panic when linkerd checks try to access the Kubernetes API:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/linkerd/linkerd2/pkg/k8s.(*KubernetesAPI).CoreV1(...)
github.com/linkerd/linkerd2/pkg/config.FetchLinkerdConfigMap(...)
```

## Solution
- Call `hc.InitializeKubeAPIClient()` before `hc.RunChecks()`
- Return a proper error response if initialization fails
- Fixed `CNIEnabled` to use `cfg.CNIEnabled` instead of `cfg.Enabled`
